### PR TITLE
Makes links on the homepage relative instead of pointing to the root /;

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -11,7 +11,7 @@
 
 		<!-- css -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-		<link href="/css/main.css?v=1" rel="stylesheet">
+		<link href="css/main.css?v=1" rel="stylesheet">
 
 		<!-- IE8 support of HTML5 elements and media queries -->
 		<!--[if lt IE 9]>
@@ -24,7 +24,7 @@
 
 		<div class="container">
 			<h1>
-				<img src="/images/ireceptor_logo.png">
+				<img src="images/ireceptor_logo.png">
 				iReceptor Repository
 			</h1>
 
@@ -41,8 +41,8 @@
 
 					<h2>iReceptor API</h2>
 					<ul>
-						<li><a href="/v2/samples">/v2/samples</a></li>
-						<li><a href="/v2/sequences_summary">/v2/sequences_summary</a></li>
+						<li><a href="v2/samples">/v2/samples</a></li>
+						<li><a href="v2/sequences_summary">/v2/sequences_summary</a></li>
 					</ul>
 					<p>For more information about the iReceptor API, visit the <a href="https://github.com/sfu-ireceptor/api">iReceptor API definition</a> on GitHub.</p>
 


### PR DESCRIPTION
Hello,

This change makes links to resources relative instead of pointing to `/`.

I made this change because I'm hosting the service on a docker container that's routing several services through a reverse proxy.

Example: This particular service is reachable through `https://<myserver>/turnkey` on my server. If I tried to reach the homepage the logo would point to `https://<myserver>/public/images/ireceptor_logo.png` instead of `https://<myserver>/turnkey/public/images/ireceptor_logo.png`

Does this change make sense?

All the best.

EDIT: I wasn't sure which branch to edit, so I went for the one with the most recent changes (`airr_api`), hopefully I got it right...?