### PR TITLE
fix single rearrangement not found reponse schema

### DIFF
--- a/app/Http/Controllers/AirrApiController.php
+++ b/app/Http/Controllers/AirrApiController.php
@@ -209,7 +209,7 @@ class AirrApiController extends Controller
         if (isset($rearrangement[0])) {
             $response['Rearrangement'] = AirrRearrangement::airrRearrangementResponseSingle($rearrangement[0]);
         } else {
-            $response['Rearrangement'] = '{[]}';
+            $response['Rearrangement'] = [];
         }
 
         return response($response)->header('Content-Type', 'application/json');


### PR DESCRIPTION
Update response when a user GET's a non existing rearrangement to be ADC compliant